### PR TITLE
Add SSL context support when downloading the antlr.jar file

### DIFF
--- a/antlerinator/config.json
+++ b/antlerinator/config.json
@@ -4,6 +4,6 @@
     "antlr4-python2-runtime==4.7.1; python_version~='2.7'",
     "antlr4-python3-runtime==4.7.1; python_version>='3.0'"
   ],
-  "tool_url": "http://www.antlr.org/download/antlr-4.7.1-complete.jar",
+  "tool_url": "https://www.antlr.org/download/antlr-4.7.1-complete.jar",
   "tool_name": "antlr-4.7.1-complete.jar"
 }

--- a/antlerinator/install.py
+++ b/antlerinator/install.py
@@ -9,6 +9,7 @@ import contextlib
 import errno
 import json
 import pkgutil
+import ssl
 
 from argparse import ArgumentParser
 from os import makedirs
@@ -42,7 +43,8 @@ def install(force=False, lazy=False):
             raise OSError(errno.EEXIST, 'file already exists', antlr_jar_path)
 
     tool_url = config['tool_url']
-    with contextlib.closing(urlopen(tool_url)) as response:
+    ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+    with contextlib.closing(urlopen(tool_url, context=ssl_context)) as response:
         tool_jar = response.read()
 
     if not isdir(dirname(antlr_jar_path)):


### PR DESCRIPTION
The tool_url used in the config is a http url. However when that url is accessed
the server sends a redirection (http 301 code) to the correct https url.
On Windows using the https url triggers SSL certificate errors (using Python 3.6).

Adding SSL context creating to avoid such issues.
In addition the tool_url is changed to use the https url and thus removed the
automatic redirection when accessing the jar file.