### PR TITLE
Update project for Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 'pypy-3.7']
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 'pypy-3.7']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -17,7 +17,8 @@ disable=
     too-many-instance-attributes, too-few-public-methods,
     redefined-builtin, broad-except, protected-access,
     useless-object-inheritance, unnecessary-pass, duplicate-code,
-    function-redefined, attribute-defined-outside-init, consider-using-with
+    function-redefined, attribute-defined-outside-init, consider-using-with,
+    consider-using-f-string
 
 [REPORTS]
 

--- a/src/antlerinator/download.py
+++ b/src/antlerinator/download.py
@@ -72,7 +72,7 @@ def download(version=None, path=None, *, force=False, lazy=False):
         if not force:
             raise OSError(errno.EEXIST, 'file already exists', tool_path)
 
-    ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+    ssl_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
     with contextlib.closing(urlopen(tool_url, context=ssl_context)) as response:
         tool_bytes = response.read()
 


### PR DESCRIPTION
- Fix SSL context creation to use proper purpose.
  To create client-side sockets, SERVER_AUTH purpose should be
  used. Since Python 3.10, this is enforced strictly, and
  CLIENT_AUTH purpose configures the context incorrectly, with a
  protocol setting (PROTOCOL_TLS_SERVER) that cannot be used for
  client sockets.
- Test Python 3.10 on GH Actions.
- Disable consider-using-f-string pylint diagnostics.
  As ANTLeRinator still supports Python 3.5, f-strings are not an
  option, yet.