### PR TITLE
Fix (or rather silence) pylint issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,7 @@
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
+    useless-option-value,
     line-too-long, fixme, missing-docstring, invalid-name, no-self-use, unused-argument,
     wildcard-import, unused-wildcard-import, ungrouped-imports,
     too-many-arguments, too-many-locals,
@@ -18,7 +19,7 @@ disable=
     redefined-builtin, broad-except, protected-access,
     useless-object-inheritance, unnecessary-pass, duplicate-code,
     function-redefined, attribute-defined-outside-init, consider-using-with,
-    consider-using-f-string
+    consider-using-f-string, deprecated-module
 
 [REPORTS]
 

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2021 Renata Hodovan, Akos Kiss.
+Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ import sys
 
 project = 'ANTLeRinator'
 author = 'Renata Hodovan, Akos Kiss'
-copyright = '2017-2021, %s' % author
+copyright = '2017-2022, %s' % author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
- `no-self-use` warning had to be disabled previously for pylint
  because some methods did not use self. But recent pylint does not
  check for `no-self-use` anymore, and so listing it as disabled
  causes a warning. As both older and newer pylint versions are to
  be supported, the new warning is also disabled.
- Since py3.10, distutils is deprecated. There is no work in
  progress to substitute it yet, so the deprecation warning is
  disabled.