### PR TITLE
Ensure that editable wheels also get lexers/parsers built

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,8 @@ build-time from ``.g4`` grammars. It adds two new *Setuptools* commands,
 ``build_antlr`` and ``clean_antlr``, to perform the building and the cleanup of
 lexers/parsers, and also ensures that these new commands are invoked by the
 standard ``build`` (``install``), ``develop``, ``clean``, and ``sdist`` commands
-as appropriate. The building of lexers/parsers is performed using the *ANTLRv4*
+as well as by the *Setuptools*-internal ``editable_wheel`` command as
+appropriate. The building of lexers/parsers is performed using the *ANTLRv4*
 tool and is controlled by the ``[build_antlr]`` section in ``setup.cfg``:
 
 .. code-block:: ini

--- a/src/antlerinator/build_antlr.py
+++ b/src/antlerinator/build_antlr.py
@@ -11,7 +11,7 @@ import re
 import shlex
 import sys
 
-from distutils.errors import DistutilsOptionError
+from distutils.errors import DistutilsModuleError, DistutilsOptionError
 from setuptools import Command
 
 from .download import download
@@ -139,3 +139,16 @@ def register(dist):
     dist.cmdclass['develop'] = antlerinator_develop
     dist.cmdclass['clean'] = antlerinator_clean
     dist.cmdclass['sdist'] = antlerinator_sdist
+
+    # Patch editable_wheel only if available
+    try:
+        editable_wheel = dist.get_command_class('editable_wheel')
+
+        class antlerinator_editable_wheel(editable_wheel):
+            def run(self):
+                self.run_command('build_antlr')
+                editable_wheel.run(self)
+
+        dist.cmdclass['editable_wheel'] = antlerinator_editable_wheel
+    except DistutilsModuleError:
+        pass


### PR DESCRIPTION
For the sake of compatibility with some plugins, setuptools changed the behavior of the internal `editable_wheel` command not to run the `build` command, but to run its subcommands only. However, this broke ANTLeRinator, as it relied on `build` to run `build_antlr` to build any lexers/parsers. Now, `editable_wheel` is patched to ensure that `build_antlr` is called.