### PR TITLE
Drop support of Python3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -19,7 +19,7 @@ disable=
     redefined-builtin, broad-except, protected-access,
     useless-object-inheritance, unnecessary-pass, duplicate-code,
     function-redefined, attribute-defined-outside-init, consider-using-with,
-    consider-using-f-string, deprecated-module
+    deprecated-module
 
 [REPORTS]
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ ANTLR v4 in sync.
 Requirements
 ============
 
-* Python_ >= 3.5
+* Python_ >= 3.6
 * Java_ SE >= 7 JRE or JDK (the latter is optional)
 
 .. _Python: https://www.python.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,12 +14,12 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Code Generators
 platform = any
 
@@ -27,7 +27,7 @@ platform = any
 package_dir =
     = src
 packages = find:
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     importlib-metadata; python_version < "3.8"
     inators

--- a/src/antlerinator/arg.py
+++ b/src/antlerinator/arg.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -16,7 +16,7 @@ def add_antlr_argument(
         long_alias=(),
         *,
         metavar='FILE',
-        help='path of the ANTLR v4 tool jar file (default: %s)' % default_antlr_jar_path(__antlr_version__ or 'VERSION')
+        help=f'path of the ANTLR v4 tool jar file (default: {default_antlr_jar_path(__antlr_version__ or "VERSION")})'
 ):
     """
     add_antlr_argument(parser, short_alias=(), long_alias=(), *, metavar='FILE', help='path of the ANTLR v4 tool jar file (default:  ~/.antlerinator/antlr-VERSION-complete.jar)')

--- a/src/antlerinator/build_antlr.py
+++ b/src/antlerinator/build_antlr.py
@@ -44,7 +44,7 @@ class build_antlr(Command):
             commands = [cmd.strip() for cmd in commands if cmd.strip()]
 
         if not isinstance(commands, list):
-            raise DistutilsOptionError("'commands' must be a list of strings or tuples (got %r)" % commands)
+            raise DistutilsOptionError(f"'commands' must be a list of strings or tuples (got {commands!r})")
 
         cmd_re = re.compile('^(?P<provider>^[^\\d\\W]\\w*):(?P<provider_arg>\\S*)\\s+(?P<antlr_args>.*)$')
         providers = {
@@ -57,21 +57,21 @@ class build_antlr(Command):
             if isinstance(cmd, str):
                 m = cmd_re.match(cmd)
                 if not m:
-                    raise DistutilsOptionError("strings in 'commands' must start with a 'provider:arg' pattern (got %r)" % cmd)
+                    raise DistutilsOptionError(f"strings in 'commands' must start with a 'provider:arg' pattern (got {cmd!r})")
                 provider, provider_arg, antlr_args = m.group('provider', 'provider_arg', 'antlr_args')
 
                 provider = providers.get(provider)
                 if not provider:
-                    raise DistutilsOptionError("unknown provider in 'commands' (options: %s; got: %s)" % (', '.join(providers.keys()), provider))
+                    raise DistutilsOptionError(f"unknown provider in 'commands' (options: {', '.join(providers.keys())}; got: {provider})")
                 antlr_args = tuple(shlex.split(antlr_args, posix=posix))
 
                 cmd = (provider, provider_arg, antlr_args)
 
             if isinstance(cmd, tuple):
                 if len(cmd) != 3:
-                    raise DistutilsOptionError("tuples in 'commands' must be 3-tuples (got %r)" % cmd)
+                    raise DistutilsOptionError(f"tuples in 'commands' must be 3-tuples (got {cmd!r})")
             else:
-                raise DistutilsOptionError("elements in 'commands' must be strings or tuples (got %r)" % commands)
+                raise DistutilsOptionError(f"elements in 'commands' must be strings or tuples (got {commands!r})")
 
             commands[i] = cmd
 

--- a/src/antlerinator/download.py
+++ b/src/antlerinator/download.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -42,7 +42,7 @@ def default_antlr_jar_path(version=None):
     version = version or __antlr_version__
     if not version:
         raise ValueError('version must be specified if antlr4 runtime is not installed')
-    return join(expanduser('~'), '.antlerinator', 'antlr-{version}-complete.jar'.format(version=version))
+    return join(expanduser('~'), '.antlerinator', f'antlr-{version}-complete.jar')
 
 
 def download(version=None, path=None, *, force=False, lazy=False):
@@ -64,7 +64,7 @@ def download(version=None, path=None, *, force=False, lazy=False):
 
     default_tool_path = default_antlr_jar_path(version)
     tool_path = path or default_tool_path
-    tool_url = 'https://www.antlr.org/download/{name}'.format(name=basename(default_tool_path))
+    tool_url = f'https://www.antlr.org/download/{basename(default_tool_path)}'
 
     if exists(tool_path):
         if lazy:
@@ -96,7 +96,7 @@ def execute():
     arg_parser.add_argument('--antlr-version', metavar='VERSION', default=__antlr_version__,
                             help='version of ANTLR v4 tool jar to download (default: %(default)s)')
     arg_parser.add_argument('--output', metavar='FILE', default=None,
-                            help='path to save the downloaded jar to (default: %s)' % default_antlr_jar_path('VERSION').replace(expanduser('~'), '~'))
+                            help=f'path to save the downloaded jar to (default: {default_antlr_jar_path("VERSION").replace(expanduser("~"), "~")})')
 
     mode_group = arg_parser.add_mutually_exclusive_group()
     mode_group.add_argument('--force', action='store_true', default=False,

--- a/tests/test_build_antlr.py
+++ b/tests/test_build_antlr.py
@@ -44,16 +44,10 @@ def test_build_antlr_providers(tmpdir):
             script_args=['build_antlr'],
             options=dict(
                 build_antlr=dict(
-                    commands='''
-                        antlerinator:{tested_antlr_version} {grammar1} -Dlanguage=Python3 -o {tmpdir} -Xexact-output-dir
-                        file:{antlr_jar_path} {grammar2} -Dlanguage=Python3 -o {tmpdir} -Xexact-output-dir
-                    '''.format(
-                        tested_antlr_version=tested_antlr_version,
-                        antlr_jar_path=antlr_jar_path,
-                        grammar1=join(resources_dir, 'Hello.g4'),
-                        grammar2=join(resources_dir, 'Bello.g4'),
-                        tmpdir=tmpdir,
-                    ),
+                    commands=f'''
+                        antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {tmpdir} -Xexact-output-dir
+                        file:{antlr_jar_path} {join(resources_dir, "Bello.g4")} -Dlanguage=Python3 -o {tmpdir} -Xexact-output-dir
+                    ''',
                 ),
             ),
         ))
@@ -79,7 +73,7 @@ def test_build_antlr_java(tmpdir):
             options=dict(
                 build_antlr=dict(
                     commands='file:antlr.jar Dummy.g4',
-                    java=join(resources_dir, 'mock_java') + script_ext,
+                    java=f'{join(resources_dir, "mock_java")}{script_ext}',
                 ),
             ),
         ))
@@ -102,14 +96,10 @@ def test_build(tmpdir):
             name='pkg',
             packages=['pkg'],
             script_name='setup.py',
-            script_args=['build', '--build-lib={buildlib}'.format(buildlib=join('build', 'lib'))],  # NOTE: --build-lib is necessary to ensure that purelib build directory is used
+            script_args=['build', f'--build-lib={join("build", "lib")}'],  # NOTE: --build-lib is necessary to ensure that purelib build directory is used
             options=dict(
                 build_antlr=dict(
-                    commands='antlerinator:{tested_antlr_version} {grammar} -Dlanguage=Python3 -o {pkgdir} -Xexact-output-dir'.format(
-                        tested_antlr_version=tested_antlr_version,
-                        grammar=join(resources_dir, 'Hello.g4'),
-                        pkgdir=join(str(tmpdir), 'pkg'),
-                    ),
+                    commands=f'antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {join(str(tmpdir), "pkg")} -Xexact-output-dir',
                 ),
             ),
         ))
@@ -136,11 +126,7 @@ def test_develop(tmpdir):
             script_args=['develop'],
             options=dict(
                 build_antlr=dict(
-                    commands='antlerinator:{tested_antlr_version} {grammar} -Dlanguage=Python3 -o {pkgdir} -Xexact-output-dir'.format(
-                        tested_antlr_version=tested_antlr_version,
-                        grammar=join(resources_dir, 'Hello.g4'),
-                        pkgdir=join(str(tmpdir), 'pkg'),
-                    ),
+                    commands=f'antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {join(str(tmpdir), "pkg")} -Xexact-output-dir',
                 ),
             ),
         ))
@@ -168,11 +154,7 @@ def test_editable_wheel(tmpdir):
             script_args=['editable_wheel'],
             options=dict(
                 build_antlr=dict(
-                    commands='antlerinator:{tested_antlr_version} {grammar} -Dlanguage=Python3 -o {pkgdir} -Xexact-output-dir'.format(
-                        tested_antlr_version=tested_antlr_version,
-                        grammar=join(resources_dir, 'Hello.g4'),
-                        pkgdir=join(str(tmpdir), 'pkg'),
-                    ),
+                    commands=f'antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {join(str(tmpdir), "pkg")} -Xexact-output-dir',
                 ),
             ),
         ))

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -46,15 +46,15 @@ def run_download(args, exp_ok):
 class TestDownload(object):
 
     def test_cli(self, antlr_version, default_path, tmpdir):
-        args = ['--antlr-version=%s' % antlr_version]
+        args = [f'--antlr-version={antlr_version}']
 
         if not default_path:
             jar_path = os.path.join(str(tmpdir), 'antlr4.jar')
-            args += ['--output=%s' % jar_path]
+            args += [f'--output={jar_path}']
         else:
             jar_path = antlerinator.default_antlr_jar_path(antlr_version)
 
-        run_download(args=tuple(args) + ('--force', ),exp_ok=True)
+        run_download(args=tuple(args) + ('--force', ), exp_ok=True)
         run_download(args=tuple(args) + ('--lazy', ), exp_ok=True)
         run_download(args=tuple(args), exp_ok=False)
         run_antlr(jar_path)


### PR DESCRIPTION
Python3.5 has reached the end of its lifetime two years ago, hence Antlerinator also stops supporting it. The patch introduces the usage of f-strings - supported from Python3.6 - and unifies string representations to use it where possible.
It also enables the 'consider-using-f-string' pylint checker.