### PR TITLE
Don't clean generated files before creating an sdist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,10 +142,10 @@ Building lexers/parsers at build-time with ANTLRv4
 build-time from ``.g4`` grammars. It adds two new *Setuptools* commands,
 ``build_antlr`` and ``clean_antlr``, to perform the building and the cleanup of
 lexers/parsers, and also ensures that these new commands are invoked by the
-standard ``build`` (``install``), ``develop``, ``clean``, and ``sdist`` commands
-as well as by the *Setuptools*-internal ``editable_wheel`` command as
-appropriate. The building of lexers/parsers is performed using the *ANTLRv4*
-tool and is controlled by the ``[build_antlr]`` section in ``setup.cfg``:
+standard ``build`` (``install``), ``develop``, and ``clean`` commands as well as
+by the *Setuptools*-internal ``editable_wheel`` command as appropriate. The
+building of lexers/parsers is performed using the *ANTLRv4* tool and is
+controlled by the ``[build_antlr]`` section in ``setup.cfg``:
 
 .. code-block:: ini
 

--- a/src/antlerinator/build_antlr.py
+++ b/src/antlerinator/build_antlr.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -113,7 +113,6 @@ def register(dist):
     build = dist.get_command_class('build')
     develop = dist.get_command_class('develop')
     clean = dist.get_command_class('clean')
-    sdist = dist.get_command_class('sdist')
 
     class antlerinator_build(build):
         def run(self):
@@ -130,15 +129,9 @@ def register(dist):
             self.run_command('clean_antlr')
             clean.run(self)
 
-    class antlerinator_sdist(sdist):
-        def run(self):
-            self.run_command('clean_antlr')
-            sdist.run(self)
-
     dist.cmdclass['build'] = antlerinator_build
     dist.cmdclass['develop'] = antlerinator_develop
     dist.cmdclass['clean'] = antlerinator_clean
-    dist.cmdclass['sdist'] = antlerinator_sdist
 
     # Patch editable_wheel only if available
     try:

--- a/tests/test_build_antlr.py
+++ b/tests/test_build_antlr.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -199,7 +199,8 @@ def test_clean(tmpdir):
 
 def test_sdist(tmpdir):
     """
-    Test whether generated files are cleaned before creating an sdist.
+    Test whether generated files can be excluded from the sdist using
+    MANIFEST.in.
     """
     with tmpdir.as_cwd():
         dist = Distribution(dict(
@@ -216,6 +217,8 @@ def test_sdist(tmpdir):
         open(join('pkg', '__init__.py'), 'w').close()
         open(join('pkg', 'DummyLexer.py'), 'w').close()
         open(join('pkg', 'DummyParser.py'), 'w').close()
+        with open('MANIFEST.in', 'w') as f:
+            f.write('exclude pkg/Dummy*.py')
 
         sdist = dist.get_command_class('sdist')
         cmd = sdist(dist)


### PR DESCRIPTION
To exclude generated files, some other mechanism should be used (e.g., MANIFEST.in).