### PR TITLE
Ensure test quality via linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -19,6 +19,7 @@ disable=
     redefined-builtin,
     too-few-public-methods,
     too-many-branches,
+    unspecified-encoding,
     useless-option-value,  # disables warning in recent pylint that does not check for no-self-use anymore
 
 [REPORTS]

--- a/tests/test_build_antlr.py
+++ b/tests/test_build_antlr.py
@@ -5,12 +5,14 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import pytest
 import sys
 
+from distutils.errors import DistutilsModuleError
 from os import makedirs
 from os.path import abspath, dirname, isfile, join
-from distutils.errors import DistutilsModuleError
+
+import pytest
+
 from setuptools.dist import Distribution
 
 import antlerinator
@@ -38,19 +40,19 @@ def test_build_antlr_providers(tmpdir):
     with tmpdir.as_cwd():
         antlr_jar_path = antlerinator.download(version=tested_antlr_version, path=join(str(tmpdir), 'antlr.jar'))
 
-        dist = Distribution(dict(
-            name='pkg',
-            script_name='setup.py',
-            script_args=['build_antlr'],
-            options=dict(
-                build_antlr=dict(
-                    commands=f'''
+        dist = Distribution({
+            'name': 'pkg',
+            'script_name': 'setup.py',
+            'script_args': ['build_antlr'],
+            'options': {
+                'build_antlr': {
+                    'commands': f'''
                         antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {tmpdir} -Xexact-output-dir
                         file:{antlr_jar_path} {join(resources_dir, "Bello.g4")} -Dlanguage=Python3 -o {tmpdir} -Xexact-output-dir
                     ''',
-                ),
-            ),
-        ))
+                },
+            },
+        })
 
         dist.parse_command_line()
         dist.run_commands()
@@ -66,17 +68,17 @@ def test_build_antlr_java(tmpdir):
     Test whether ``build_antlr`` can deal with a custom java VM.
     """
     with tmpdir.as_cwd():
-        dist = Distribution(dict(
-            name='pkg',
-            script_name='setup.py',
-            script_args=['build_antlr'],
-            options=dict(
-                build_antlr=dict(
-                    commands='file:antlr.jar Dummy.g4',
-                    java=f'{join(resources_dir, "mock_java")}{script_ext}',
-                ),
-            ),
-        ))
+        dist = Distribution({
+            'name': 'pkg',
+            'script_name': 'setup.py',
+            'script_args': ['build_antlr'],
+            'options': {
+                'build_antlr': {
+                    'commands': 'file:antlr.jar Dummy.g4',
+                    'java': f'{join(resources_dir, "mock_java")}{script_ext}',
+                },
+            },
+        })
 
         dist.parse_command_line()
         dist.run_commands()
@@ -92,19 +94,20 @@ def test_build(tmpdir):
     command is invoked (which is also invoked during ``install``).
     """
     with tmpdir.as_cwd():
-        dist = Distribution(dict(
-            name='pkg',
-            packages=['pkg'],
-            script_name='setup.py',
-            script_args=['build', f'--build-lib={join("build", "lib")}'],  # NOTE: --build-lib is necessary to ensure that purelib build directory is used
-            options=dict(
-                build_antlr=dict(
-                    commands=f'antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {join(str(tmpdir), "pkg")} -Xexact-output-dir',
-                ),
-            ),
-        ))
+        dist = Distribution({
+            'name': 'pkg',
+            'packages': ['pkg'],
+            'script_name': 'setup.py',
+            'script_args': ['build', f'--build-lib={join("build", "lib")}'],  # NOTE: --build-lib is necessary to ensure that purelib build directory is used
+            'options': {
+                'build_antlr': {
+                    'commands': f'antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {join(str(tmpdir), "pkg")} -Xexact-output-dir',
+                },
+            },
+        })
         makedirs('pkg')
-        open(join('pkg', '__init__.py'), 'w').close()
+        with open(join('pkg', '__init__.py'), 'w'):
+            pass
 
         dist.parse_command_line()
         dist.run_commands()
@@ -119,19 +122,20 @@ def test_develop(tmpdir):
     development mode).
     """
     with tmpdir.as_cwd():
-        dist = Distribution(dict(
-            name='pkg',
-            packages=['pkg'],
-            script_name='setup.py',
-            script_args=['develop'],
-            options=dict(
-                build_antlr=dict(
-                    commands=f'antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {join(str(tmpdir), "pkg")} -Xexact-output-dir',
-                ),
-            ),
-        ))
+        dist = Distribution({
+            'name': 'pkg',
+            'packages': ['pkg'],
+            'script_name': 'setup.py',
+            'script_args': ['develop'],
+            'options': {
+                'build_antlr': {
+                    'commands': f'antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {join(str(tmpdir), "pkg")} -Xexact-output-dir',
+                },
+            },
+        })
         makedirs('pkg')
-        open(join('pkg', '__init__.py'), 'w').close()
+        with open(join('pkg', '__init__.py'), 'w'):
+            pass
 
         dist.parse_command_line()
         dist.run_commands()
@@ -147,19 +151,20 @@ def test_editable_wheel(tmpdir):
     editable wheels).
     """
     with tmpdir.as_cwd():
-        dist = Distribution(dict(
-            name='pkg',
-            packages=['pkg'],
-            script_name='setup.py',
-            script_args=['editable_wheel'],
-            options=dict(
-                build_antlr=dict(
-                    commands=f'antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {join(str(tmpdir), "pkg")} -Xexact-output-dir',
-                ),
-            ),
-        ))
+        dist = Distribution({
+            'name': 'pkg',
+            'packages': ['pkg'],
+            'script_name': 'setup.py',
+            'script_args': ['editable_wheel'],
+            'options': {
+                'build_antlr': {
+                    'commands': f'antlerinator:{tested_antlr_version} {join(resources_dir, "Hello.g4")} -Dlanguage=Python3 -o {join(str(tmpdir), "pkg")} -Xexact-output-dir',
+                },
+            },
+        })
         makedirs('pkg')
-        open(join('pkg', '__init__.py'), 'w').close()
+        with open(join('pkg', '__init__.py'), 'w'):
+            pass
 
         dist.parse_command_line()
         dist.run_commands()
@@ -173,21 +178,24 @@ def test_clean(tmpdir):
     Test whether cleanup removes generated files.
     """
     with tmpdir.as_cwd():
-        dist = Distribution(dict(
-            name='pkg',
-            packages=['pkg'],
-            script_name='setup.py',
-            script_args=['clean'],
-            options=dict(
-                build_antlr=dict(
-                    output=join('pkg', 'Dummy*.py'),
-                ),
-            ),
-        ))
+        dist = Distribution({
+            'name': 'pkg',
+            'packages': ['pkg'],
+            'script_name': 'setup.py',
+            'script_args': ['clean'],
+            'options': {
+                'build_antlr': {
+                    'output': join('pkg', 'Dummy*.py'),
+                },
+            },
+        })
         makedirs('pkg')
-        open(join('pkg', '__init__.py'), 'w').close()
-        open(join('pkg', 'DummyLexer.py'), 'w').close()
-        open(join('pkg', 'DummyParser.py'), 'w').close()
+        with open(join('pkg', '__init__.py'), 'w'):
+            pass
+        with open(join('pkg', 'DummyLexer.py'), 'w'):
+            pass
+        with open(join('pkg', 'DummyParser.py'), 'w'):
+            pass
 
         dist.parse_command_line()
         dist.run_commands()
@@ -203,20 +211,23 @@ def test_sdist(tmpdir):
     MANIFEST.in.
     """
     with tmpdir.as_cwd():
-        dist = Distribution(dict(
-            name='pkg',
-            packages=['pkg'],
-            script_name='setup.py',
-            options=dict(
-                build_antlr=dict(
-                    output=join('pkg', 'Dummy*.py'),
-                ),
-            ),
-        ))
+        dist = Distribution({
+            'name': 'pkg',
+            'packages': ['pkg'],
+            'script_name': 'setup.py',
+            'options': {
+                'build_antlr': {
+                    'output': join('pkg', 'Dummy*.py'),
+                },
+            },
+        })
         makedirs('pkg')
-        open(join('pkg', '__init__.py'), 'w').close()
-        open(join('pkg', 'DummyLexer.py'), 'w').close()
-        open(join('pkg', 'DummyParser.py'), 'w').close()
+        with open(join('pkg', '__init__.py'), 'w'):
+            pass
+        with open(join('pkg', 'DummyLexer.py'), 'w'):
+            pass
+        with open(join('pkg', 'DummyParser.py'), 'w'):
+            pass
         with open('MANIFEST.in', 'w') as f:
             f.write('exclude pkg/Dummy*.py')
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2017-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,9 +6,10 @@
 # according to those terms.
 
 import os
-import pytest
 import subprocess
 import sys
+
+import pytest
 
 import antlerinator
 
@@ -43,7 +44,7 @@ def run_download(args, exp_ok):
     True,
     False
 ])
-class TestDownload(object):
+class TestDownload:
 
     def test_cli(self, antlr_version, default_path, tmpdir):
         args = [f'--antlr-version={antlr_version}']

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ usedevelop = true
 deps =
     pycodestyle
     pylint
+    pytest
 commands =
-    pylint src/antlerinator
-    pycodestyle src/antlerinator --ignore=E501
+    pylint src/antlerinator tests
+    pycodestyle src/antlerinator tests --ignore=E501
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
- List standard modules first in imports.
- Use dict literals.
- Use with when opening files.
- Don't specify object as superclass.