### PR TITLE
Test Python 3.12 on GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.9']
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12', 'pypy-3.9']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'  # FIXME: on py3.12.0, editable wheels fail (reported using distutils.errors.DistutilsModuleError)
+          python-version: '3.x'
       - uses: actions/setup-java@v3
         with:
           java-version: 17

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     importlib-metadata; python_version < "3.8"
     inators
     setuptools
+    wheel
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Added wheel as install requirement since in some setuptools versions the implementation of the editable_wheels command is based on wheel's bdist_wheel command. Triggered only on py312.