### PR TITLE
Remove support of Python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12', 'pypy-3.9']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', 'pypy-3.9']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ ANTLR v4 in sync.
 Requirements
 ============
 
-* Python_ >= 3.7
+* Python_ >= 3.8
 * Java_ SE >= 7 JRE or JDK (the latter is optional)
 
 .. _Python: https://www.python.org

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,11 +14,11 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Code Generators
 platform = any
 
@@ -26,9 +26,8 @@ platform = any
 package_dir =
     = src
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
-    importlib-metadata; python_version < "3.8"
     inators
     setuptools
     wheel


### PR DESCRIPTION
Python 3.7 reached its end of life in June 2023 and it is not even supported by some of the GH actions.