### PR TITLE
Fix testing of editable installs via development mode

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2024 Renata Hodovan, Akos Kiss.
+Copyright (c) 2017-2025 Renata Hodovan, Akos Kiss.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ import sys
 
 project = 'ANTLeRinator'
 author = 'Renata Hodovan, Akos Kiss'
-copyright = '2017-2024, %s' % author
+copyright = '2017-2025, %s' % author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/tests/test_build_antlr.py
+++ b/tests/test_build_antlr.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2025 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -136,6 +136,8 @@ def test_develop(tmpdir):
         makedirs('pkg')
         with open(join('pkg', '__init__.py'), 'w'):
             pass
+        with open('setup.py', 'w') as f:
+            f.write('from setuptools import setup; setup(name="pkg", packages=["pkg"])')
 
         dist.parse_command_line()
         dist.run_commands()


### PR DESCRIPTION
Recent changes in setuptools mandate a proper `setup.py` in the test package.

Also: Update years in license and docs